### PR TITLE
fix autogen types for mockauth helper

### DIFF
--- a/src/http/nodegen/tests/___eval.ts
+++ b/src/http/nodegen/tests/___eval.ts
@@ -407,8 +407,6 @@ export const defaultSetupTeardown = () => {
   }\
 };
 
-export type Async<T> = T extends (...args: infer T) => infer T ? Promise<T> : never;
-
 /**
  * Auth middleware mocker
  *
@@ -419,7 +417,7 @@ export type Async<T> = T extends (...args: infer T) => infer T ? Promise<T> : ne
  *
  * @param {RequestHandler}  middleware  Replaces AccessTokenService.validateRequest
  */
-export const mockAuth = (middleware?: Async<RequestHandler>) => {
+export const mockAuth = (middleware?: RequestHandler) => {
   jest
     .spyOn(AccessTokenService, 'validateRequest')
     .mockImplementation(


### PR DESCRIPTION
async typing always returns "never", forcing any typing. Just allowing middleware seems to accept async middleware by default so will do that instead