### PR TITLE
fix: express types conflict in celebrate latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@types/command-line-args": "^5.0.1",
     "@types/cors": "^2.8.10",
-    "@types/express": "4.17.7",
+    "@types/express": "^4.17.13",
     "@types/express-form-data": "^2.0.2",
     "@types/fs-extra": "^9.0.12",
     "@types/jest": "^26.0.24",


### PR DESCRIPTION
update @types/express closes #174