### PR TITLE
fix: dockerfile fails to run if load_swagger_ui_route passed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,26 @@
-FROM node:14-alpine as environment
+FROM node:16 as build
 
 WORKDIR /code
 
 COPY ./package.json ./package-lock.json /code/
-
 RUN npm ci
 
-# -----------------------------------------------------
-FROM environment as build
-
 COPY . /code
-
 RUN npm run build
 
 # -----------------------------------------------------
-FROM environment as runtime
+FROM node:16-alpine as runtime
 
+WORKDIR /code
+
+COPY --from=build /code/package.json /code/package.json
+# FIXME: should only install prod deps for runtime
+# RUN npm i --production
+COPY --from=build /code/node_modules /code/node_modules
 COPY --from=build /code/build /code/build
+
+COPY --from=build /code/openapi-nodegen-api-file.yml /code/openapi-nodegen-api-file.yml
+
 COPY ./docker-entrypoint.sh /sbin/
 RUN chmod 755 /sbin/docker-entrypoint.sh
 


### PR DESCRIPTION
- add missing openapi yaml file to docker
- bump node version to latest lts
- setup multistage build, with runtime on alpine lts
closes #187