### PR TITLE
joi-options-per-route

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,13 @@ Both the input and output are provided the request and response object, respecti
 
 This means that once in the domain layer you can be safe to think that there is no additional content in the request object than that specified in the swagger file.
 
-Conversely as the output is reduced, should a domain accidentally return attributes it shouldn't they will never be passed back out to the client.
+Conversely, as the output is reduced, should a domain accidentally return attributes it shouldn't they will never be passed back out to the client.
+
+Celebrate is the express middleware validating input, it uses Joi under the hood. You can inject Joi options on a path by path level via x-joi-options eg:
+```yaml
+x-joi-options:
+  allowUnknown: true
+```
 
 #### Async route validation 
 Celebrate will cover 90% of the validation needs of an API, but there is always a % of use cases wherein you need to perform an async action to before permitting the user to hit a domain layer. The most common use case is when you want to validate incoming data against a database record, for example, a registration form checking that a given email/username is not already registered. These types of validators do no always fit the Joi style of validation that is under the hood of celebrate.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Celebrate is the express middleware validating input, it uses Joi under the hood
 x-joi-options:
   allowUnknown: true
 ```
+All options can be found here: https://github.com/sideway/joi/blob/master/API.md#anyvalidatevalue-options
 
 #### Async route validation 
 Celebrate will cover 90% of the validation needs of an API, but there is always a % of use cases wherein you need to perform an async action to before permitting the user to hit a domain layer. The most common use case is when you want to validate incoming data against a database record, for example, a registration form checking that a given email/username is not already registered. These types of validators do no always fit the Joi style of validation that is under the hood of celebrate.

--- a/src/http/nodegen/routes/___op.ts.njk
+++ b/src/http/nodegen/routes/___op.ts.njk
@@ -27,7 +27,7 @@ export default function() {
         '{{op.subresource}}',
         {% if securityNames %}accessTokenMiddleware({{ securityNames }}  {% if path['x-passThruWithoutJWT'] %}, {passThruWithoutJWT: true}{% endif %}), /* Validate request security tokens */{% endif %}
         {% if path['x-permission'] %}permissionMiddleware('{{ path['x-permission'] }}'), /* Check permission of the incoming user */ {% endif %}
-        {% if pathsHasParamsToValidate(path) %}celebrate({{ _.camelCase(operation_name) }}Validators.{{path.operationId}}{% if path['x-joi-options'] %}{{ path['x-joi-options'] | dump }}{% endif %}), /* Validate the request data and return validation errors, options passed in via x-joi-options */ {% endif %}
+        {% if pathsHasParamsToValidate(path) %}celebrate({{ _.camelCase(operation_name) }}Validators.{{path.operationId}}{% if path['x-joi-options'] %}, {{ path['x-joi-options'] | dump }}{% endif %}), /* Validate the request data and return validation errors, options passed in via x-joi-options */ {% endif %}
         {% if path['x-async-validators'] %}asyncValidationMiddleware({{ path['x-async-validators'] | dump }}), /* Call an async validator function and throw an appropriate error */ {% endif %}
         {% if path['x-cache'] %}apiCaching({{_.camelCase(operation_name)}}TransformOutputs.{{path.operationId}}), /* Lastly, if x-cache is found, call the api cache middleware */ {% endif %}
         async (req: any, res: GenerateItExpressResponse) => {

--- a/src/http/nodegen/routes/___op.ts.njk
+++ b/src/http/nodegen/routes/___op.ts.njk
@@ -27,7 +27,7 @@ export default function() {
         '{{op.subresource}}',
         {% if securityNames %}accessTokenMiddleware({{ securityNames }}  {% if path['x-passThruWithoutJWT'] %}, {passThruWithoutJWT: true}{% endif %}), /* Validate request security tokens */{% endif %}
         {% if path['x-permission'] %}permissionMiddleware('{{ path['x-permission'] }}'), /* Check permission of the incoming user */ {% endif %}
-        {% if pathsHasParamsToValidate(path) %}celebrate({{ _.camelCase(operation_name) }}Validators.{{path.operationId}}{% if path['x-joi-options'] %}{{ path['x-joi-options'] }}{% endif %}), /* Validate the request data and return validation errors, options passed in via x-joi-options */ {% endif %}
+        {% if pathsHasParamsToValidate(path) %}celebrate({{ _.camelCase(operation_name) }}Validators.{{path.operationId}}{% if path['x-joi-options'] %}{{ path['x-joi-options'] | dump }}{% endif %}), /* Validate the request data and return validation errors, options passed in via x-joi-options */ {% endif %}
         {% if path['x-async-validators'] %}asyncValidationMiddleware({{ path['x-async-validators'] | dump }}), /* Call an async validator function and throw an appropriate error */ {% endif %}
         {% if path['x-cache'] %}apiCaching({{_.camelCase(operation_name)}}TransformOutputs.{{path.operationId}}), /* Lastly, if x-cache is found, call the api cache middleware */ {% endif %}
         async (req: any, res: GenerateItExpressResponse) => {

--- a/src/http/nodegen/routes/___op.ts.njk
+++ b/src/http/nodegen/routes/___op.ts.njk
@@ -27,7 +27,7 @@ export default function() {
         '{{op.subresource}}',
         {% if securityNames %}accessTokenMiddleware({{ securityNames }}  {% if path['x-passThruWithoutJWT'] %}, {passThruWithoutJWT: true}{% endif %}), /* Validate request security tokens */{% endif %}
         {% if path['x-permission'] %}permissionMiddleware('{{ path['x-permission'] }}'), /* Check permission of the incoming user */ {% endif %}
-        {% if pathsHasParamsToValidate(path) %}celebrate({{ _.camelCase(operation_name) }}Validators.{{path.operationId}}), /* Validate the request data and return validation errors */ {% endif %}
+        {% if pathsHasParamsToValidate(path) %}celebrate({{ _.camelCase(operation_name) }}Validators.{{path.operationId}}{% if path['x-joi-options'] %}{{ path['x-joi-options'] }}{% endif %}), /* Validate the request data and return validation errors, options passed in via x-joi-options */ {% endif %}
         {% if path['x-async-validators'] %}asyncValidationMiddleware({{ path['x-async-validators'] | dump }}), /* Call an async validator function and throw an appropriate error */ {% endif %}
         {% if path['x-cache'] %}apiCaching({{_.camelCase(operation_name)}}TransformOutputs.{{path.operationId}}), /* Lastly, if x-cache is found, call the api cache middleware */ {% endif %}
         async (req: any, res: GenerateItExpressResponse) => {


### PR DESCRIPTION
https://github.com/sideway/joi/blob/master/API.md#anyvalidatevalue-options
ability to inject joi options on a path by path level

eg 

```
x-joi-options:
  allowUnknown: true
```

or it looks like you can override the error message too, i think,  eg
```
x-joi-options:
  messages:
    email: <some translation key>
```