### PR TITLE
http options extending and exceptionOptions inject-able to extend the standard basic function ad-hoc  

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,14 @@ Alternatively (or additionally) see the [known-templates](https://acr-lfr.github
 ## Injecting into the http layer
 You can inject some customization into the http layer from the app.ts file.
 
-Here is an example, injecting a static route to be loaded before the http routes:
+Here is an example, injecting a static route to be loaded before the http routes and a custom 500 error handler:
 ````typescript
 import express from 'express';
 import path from 'path';
 import config from '@/config';
 import RabbitMQService from '@/events/rabbitMQ/RabbitMQService';
 import http, { Http } from '@/http';
+import customError500Handle from 'customError500Handle'
 
 /**
  * Returns a promise allowing the server or cli script to know
@@ -102,9 +103,14 @@ export default async (port: number): Promise<Http> => {
   // Return the http layer, to inject custom middleware pass the HttpOptions
   // argument. See the @/http/index.ts
   return http(port, {
-    preRouteApplicationRequestHandlers: [
+    preRouteMiddleware: [
       ['/image', express.static(path.join(config.file.baseFolderPath, config.file.resizedMount,), { maxAge: oneYearMS })]
-    ]
+    ],
+    httpExceptionOpts: {
+      hookForStatus: {
+        500: customError500Handle
+      }
+    }
   });
 };
 ````

--- a/README.md
+++ b/README.md
@@ -103,10 +103,14 @@ export default async (port: number): Promise<Http> => {
   // Return the http layer, to inject custom middleware pass the HttpOptions
   // argument. See the @/http/index.ts
   return http(port, {
+    // Here we are injecting an express static route into the API, preRouteMiddleware will be injected before your API routes 
+    // Other examples useful here are API throttling middleware
     preRouteMiddleware: [
       ['/image', express.static(path.join(config.file.baseFolderPath, config.file.resizedMount,), { maxAge: oneYearMS })]
     ],
-    httpExceptionOpts: {
+    // This server comes built with a generic exception handler, should you wish to inject additional custom handlers for 
+    // differing status codes here would be a good place
+    exceptionOpts: {
       hookForStatus: {
         500: customError500Handle
       }

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -17,8 +17,8 @@ export interface HttpOptions {
   // a preconfigured express app, if present the api will use this express app opposed to generating a new one.
   app?: Express;
 
-  // Optionally inject options into the http exception handler
-  httpExceptionOpts?: HandleExceptionOpts;
+  // Options injectable into the routes importer
+  routesImporter?: RoutesImporter;
 
   // An array of valid express ApplicationRequestHandlers (middlewares) injected BEFORE loading routes
   preRouteMiddleware?: Middlewares;
@@ -36,12 +36,12 @@ export interface HttpOptions {
    */
   postRouteApplicationRequestHandlers?: Middlewares;
 
-  // Options injectable into the routes importer
-  routesImporter?: RoutesImporter;
+  // Optionally inject options into the http exception handler
+  exceptionOpts?: HandleExceptionOpts;
 }
 
 export default async (port: number, options: HttpOptions = {}): Promise<Http> => {
-  const app = options?.app || express();
+  const app = options.app || express();
 
   const middlewareInjector = (middlewares: Middlewares) => {
     middlewares.forEach((handler: any) => {
@@ -53,36 +53,36 @@ export default async (port: number, options: HttpOptions = {}): Promise<Http> =>
     });
   };
 
-  options.preRouteMiddleware = options?.preRouteMiddleware || options?.preRouteApplicationRequestHandlers
-  options.postRouteMiddleware = options?.postRouteMiddleware || options?.postRouteApplicationRequestHandlers
+  options.preRouteMiddleware = options.preRouteMiddleware || options.preRouteApplicationRequestHandlers;
+  options.postRouteMiddleware = options.postRouteMiddleware || options.postRouteApplicationRequestHandlers;
 
   // Generally middlewares that should parse the request before hitting a route
   requestMiddleware(app);
-  if (options?.preRouteMiddleware) {
-    middlewareInjector(options?.preRouteMiddleware);
+  if (options.preRouteMiddleware) {
+    middlewareInjector(options.preRouteMiddleware);
   }
 
   // The actual API routes
-  routesImporter(app, options?.routesImporter);
+  routesImporter(app, options.routesImporter);
 
   // Built in 404 handlers
   app.use(handleExpress404());
   app.use(handleDomain404());
 
   // Custom response middlewares
-  if (options?.postRouteMiddleware) {
-    middlewareInjector(options?.postRouteMiddleware);
+  if (options.postRouteMiddleware) {
+    middlewareInjector(options.postRouteMiddleware);
   }
 
   // Lastly the catchAll handler
-  app.use(handleHttpException(options.httpExceptionOpts));
+  app.use(handleHttpException(options.exceptionOpts));
 
   // Deprecation warnings
-  if(options?.preRouteApplicationRequestHandlers){
-    console.log('preRouteApplicationRequestHandlers will be deprecated soon, please use preRouteMiddleware instead')
+  if (options.preRouteApplicationRequestHandlers) {
+    console.log('preRouteApplicationRequestHandlers will be deprecated soon, please use preRouteMiddleware instead');
   }
-  if(options?.postRouteApplicationRequestHandlers){
-    console.log('postRouteApplicationRequestHandlers will be deprecated soon, please use postRouteMiddleware instead')
+  if (options.postRouteApplicationRequestHandlers) {
+    console.log('postRouteApplicationRequestHandlers will be deprecated soon, please use postRouteMiddleware instead');
   }
 
   return {

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -4,7 +4,7 @@ import { AddressInfo } from 'net';
 import { handleDomain404, handleExpress404, handleHttpException, requestMiddleware } from '@/http/nodegen/middleware';
 import routesImporter, { RoutesImporter } from '@/http/nodegen/routesImporter';
 import packageJson from '../../package.json';
-import { HandleExceptionInjection } from '@/http/nodegen/middleware/handleHttpException';
+import { HandleExceptionOpts } from '@/http/nodegen/middleware/handleHttpException';
 
 export interface Http {
   expressApp: express.Application;
@@ -15,8 +15,8 @@ export interface HttpOptions {
   // a preconfigured express app, if present the api will use this express app opposed to generating a new one.
   app?: Express;
 
-  // Custom injection into the src/http/nodegen/middleware/handleHttpException.ts
-  handleExceptionInjection?: HandleExceptionInjection;
+  // Additional hooks will be called by the handleHttpException if present and the status code matches
+  httpExceptionOpts?: HandleExceptionOpts;
 
   // An array of valid express ApplicationRequestHandlers (middlewares) injected BEFORE loading routes
   preRouteApplicationRequestHandlers?: any | [string, any][];
@@ -58,8 +58,9 @@ export default async (port: number, options?: HttpOptions): Promise<Http> => {
   if (options?.postRouteApplicationRequestHandlers) {
     middlewareInjector(options?.postRouteApplicationRequestHandlers);
   }
+
   // Lastly the catchAll handler
-  app.use(handleHttpException(options.handleExceptionInjection));
+  app.use(handleHttpException(options.httpExceptionOpts));
 
   return {
     expressApp: app,

--- a/src/http/nodegen/errors/HttpException.ts
+++ b/src/http/nodegen/errors/HttpException.ts
@@ -2,6 +2,7 @@ import { HttpStatusMessage } from '@/http/nodegen/errors';
 
 export class HttpException extends Error {
   public status: number;
+  public message: string;
   public body: string | Record<string, any>;
 
   constructor(status: number, body?: string | Record<string, any>) {
@@ -13,14 +14,5 @@ export class HttpException extends Error {
 
     // https://github.com/Microsoft/TypeScript/wiki/FAQ#why-doesnt-extending-built-ins-like-error-array-and-map-work
     Object.setPrototypeOf(this, HttpException.prototype);
-  }
-
-  toJSON() {
-    return {
-      name: this.name,
-      status: this.status,
-      message: this.message,
-      body: this.body,
-    }
   }
 }

--- a/src/http/nodegen/middleware/handleHttpException.ts
+++ b/src/http/nodegen/middleware/handleHttpException.ts
@@ -25,11 +25,15 @@ export default (options: HandleExceptionOpts = {}) => {
     console.error(err.stack || err);
 
     if (options.hookForStatus && options.hookForStatus[err.status]) {
-      options.hookForStatus[err.status]({
-        ...err,
-        serviceName: packageJson.name,
-        time: new Date().toDateString()
-      });
+      try {
+        options.hookForStatus[err.status]({
+          ...err,
+          serviceName: packageJson.name,
+          time: new Date().toDateString()
+        });
+      } catch (e) {
+        console.error(`Error in status ${err.status} hook:`, e);
+      }
     }
 
     if (err.status === 500 && config.env === 'production') {

--- a/src/http/nodegen/middleware/handleHttpException.ts
+++ b/src/http/nodegen/middleware/handleHttpException.ts
@@ -4,19 +4,29 @@ import { HttpException } from '../errors';
 import NodegenRequest from '../interfaces/NodegenRequest';
 import config from '@/config';
 
+export interface HandleExceptionInjection {
+  handle500?: (err: HttpException) => void;
+}
+
 /**
  * Http Exception handler
  */
-export default () => (err: HttpException, req: NodegenRequest, res: express.Response, next: express.NextFunction) => {
-  if (!(err instanceof HttpException)) {
-    err = createHttpExceptionFromErr(err);
-  }
+export default (handleExceptionInjection: HandleExceptionInjection = {}) => {
+  return (err: HttpException, req: NodegenRequest, res: express.Response) => {
+    if (!(err instanceof HttpException)) {
+      err = createHttpExceptionFromErr(err);
+    }
 
-  console.error(err.stack || err);
+    console.error(err.stack || err);
 
-  if (err.status === 500 && config.env === 'production') {
-    return res.status(err.status).json({ message: 'Internal server error' });
-  } else {
-    return res.status(err.status).json(err);
-  }
-};
+    if (err.status === 500 && handleExceptionInjection.handle500) {
+      handleExceptionInjection.handle500(err);
+    }
+
+    if (err.status === 500 && config.env === 'production') {
+      return res.status(err.status).json({ message: 'Internal server error' });
+    } else {
+      return res.status(err.status).json(err);
+    }
+  };
+}


### PR DESCRIPTION
Ability to inject / extend the functionality of the base "catch-all" exception handler:  
  -   `src/http/nodegen/middleware/handleHttpException.ts`

Example use for passing in a custom 500 handler:
  -  https://github.com/acr-lfr/generate-it-typescript-server/pull/199/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R91

This option is very explicit, `exceptionOpts.hookForStatus.500` literally reads in English precisely what is meant to be.

You can alternatively use existing code and inject more middlewares in at the app.ts level, but:
- additional middelware = more memory and the express has yet another middleware to cycle through on each request
- to acheive same as `exceptionOpts.hookForStatus.500` it has to be documented somewhere, and few read docs
- to solve this issue of custom logging via injecting another middleware, the said middleware must be injected with all the good stuff the handleException is already being injected with, which when you do more than 5 times starts to be very error prone.. try a batch of 20+ services and it just not really a game anyone wants to play

The only argument to not make the error handling more configurable is an explicit way is to ensure the configuration options do not grow too big which is nice, but currently, the only way to extend is via yet another middleware and as mentioned to inject code which is already injected... ah then write it all up in the docs and hope someone reads it opposed to inventing yet another solution :)

