### PR TITLE
split out the error shaping and catchall, todo, figure out better logging

### DIFF
--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -1,7 +1,13 @@
 import express, { Express } from 'express';
 import http from 'http';
 import { AddressInfo } from 'net';
-import { handleDomain404, handleExpress404, handleHttpException, requestMiddleware } from '@/http/nodegen/middleware';
+import {
+  handleDomain404,
+  handleExpress404,
+  httpExceptionFormateMiddleware,
+  requestMiddleware,
+  httpCatchAllMiddleware
+} from '@/http/nodegen/middleware';
 import routesImporter, { RoutesImporter } from '@/http/nodegen/routesImporter';
 import packageJson from '../../package.json';
 
@@ -49,10 +55,13 @@ export default async (port: number, options?: HttpOptions): Promise<Http> => {
   // Response middlwares
   app.use(handleExpress404());
   app.use(handleDomain404());
+
+  // Error middleware
+  app.use(httpExceptionFormateMiddleware);
   if (options?.postRouteApplicationRequestHandlers) {
     useRequestHandlers(options?.postRouteApplicationRequestHandlers);
   }
-  app.use(handleHttpException());
+  app.use(httpCatchAllMiddleware);
 
   return {
     expressApp: app,

--- a/src/http/nodegen/middleware/httpCatchAllMiddleware.ts
+++ b/src/http/nodegen/middleware/httpCatchAllMiddleware.ts
@@ -7,6 +7,8 @@ import config from '@/config';
  * Http Exception handler
  */
 export default (err: HttpException, req: NodegenRequest, res: express.Response) => {
+  console.error(err.stack || err);
+
   if (err.status === 500 && config.env === 'production') {
     return res.status(err.status).json({ message: 'Internal server error' });
   } else {

--- a/src/http/nodegen/middleware/httpCatchAllMiddleware.ts
+++ b/src/http/nodegen/middleware/httpCatchAllMiddleware.ts
@@ -1,0 +1,15 @@
+import * as express from 'express';
+import { HttpException } from '../errors';
+import NodegenRequest from '../interfaces/NodegenRequest';
+import config from '@/config';
+
+/**
+ * Http Exception handler
+ */
+export default (err: HttpException, req: NodegenRequest, res: express.Response) => {
+  if (err.status === 500 && config.env === 'production') {
+    return res.status(err.status).json({ message: 'Internal server error' });
+  } else {
+    return res.status(err.status).json(err);
+  }
+}

--- a/src/http/nodegen/middleware/httpExceptionFormateMiddleware.ts
+++ b/src/http/nodegen/middleware/httpExceptionFormateMiddleware.ts
@@ -1,0 +1,15 @@
+import { createHttpExceptionFromErr } from '@/http/nodegen/utils/createHttpExceptionFromErr';
+import * as express from 'express';
+import { HttpException } from '../errors';
+import NodegenRequest from '../interfaces/NodegenRequest';
+
+/**
+ * Http Exception handler
+ */
+export default (err: HttpException, req: NodegenRequest, res: express.Response, next: express.NextFunction) => {
+  if (!(err instanceof HttpException)) {
+    err = createHttpExceptionFromErr(err);
+  }
+
+  return next(err);
+}

--- a/src/http/nodegen/middleware/index.ts
+++ b/src/http/nodegen/middleware/index.ts
@@ -9,3 +9,5 @@ export { default as handleHttpException } from './handleHttpException';
 export { default as headersCaching } from './headersCaching';
 export { default as permissionMiddleware } from './permissionMiddleware';
 export { default as queryArrayParserMiddleware } from './queryArrayParserMiddleware';
+export {default as httpExceptionFormateMiddleware}  from '@/http/nodegen/middleware/httpExceptionFormateMiddleware';
+export {default as httpCatchAllMiddleware} from '@/http/nodegen/middleware/httpCatchAllMiddleware';


### PR DESCRIPTION
this permits the dev to inject additional error handlers without needing to shape the error

the current `handleHttpException.ts` binds error shaping, logging and catch all return into a single middleware, this is left in place but not used unless pulled in by hand if someone wants to rewrtie the app.ts locally for tighter customisation 