### PR TITLE
Add config option to override console log in base exception handler

### DIFF
--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -22,6 +22,9 @@ export interface HttpOptions {
 
   // an array of valid express ApplicationRequestHandlers (middlewares) injected AFTER loading routes
   postRouteApplicationRequestHandlers?: any | [string, any][];
+
+  // optional logger which replaces console.error on application error
+  errorLogger?: (error: any) => void;
 }
 
 export default async (port: number, options?: HttpOptions): Promise<Http> => {
@@ -52,7 +55,7 @@ export default async (port: number, options?: HttpOptions): Promise<Http> => {
   if (options?.postRouteApplicationRequestHandlers) {
     useRequestHandlers(options?.postRouteApplicationRequestHandlers);
   }
-  app.use(handleHttpException());
+  app.use(handleHttpException(options.errorLogger));
 
   return {
     expressApp: app,


### PR DESCRIPTION
## Logging middleware implementation
For the unaware observer - there has been a fairly lengthy discussion around how to implement custom logging middleware, and how to least intrusively extend the functionality without overriding the handling with middleware passed in.

The discussion was spawned because in order to add custom logging to application errors, it requires duplicating the default exception handler and sharing that middleware to other services (eg via a node_module or relative import).

The main idea of all of this is to add the ability to insert some type of logging between:
- converting app errors (including from node_modules, domains throwing HttpExceptions, `throw 'anything'`) into `HttpException`s 
- responding to the request. 

This would allow the user to log the app-generated HttpException instead of the error it originated from. 

While it's possible to insert middleware which does this, it requires duplicating the conversion (`createHttpExceptionFromErr`) and duplicating the response (`return res.status(err.status).json(err);`) in some middleware passed into the `postRouteApplicationRequestHandlers` config option.

Several proposals have surfaced over the last week or so, each with their own pros and cons.

### Proposal 1
https://github.com/acr-lfr/generate-it-typescript-server/pull/199

While this achieves the same goal, the main concerns I see with this are:
1. While explicit, the configuration is overly verbose and provides a fair bit of cognitive overhead when reading and debugging, not to mention to the devs who have to understand what it is doing (as mentioned, who also likely wouldn't dive into the docs to find these options).
2. It locks the user into a single config pattern (until more prs opened to extend to the next use-case) - handle an app error based on a status code created prior to sending an http response back to the user.
3. It solves a very specific use-case, as opposed to providing a method for _any_ custom error handling logic to be inserted (more easily than with the currently supported custom middleware in `postRouteApplicationRequestHandlers`).
4. For users not interested in providing error code handlers, there are extra checks and try / catch methods which would not be used. This is harder to understand / debug when digging through the code, and (minorly) slows down the base exception handling.
5. It provides a surface area for errors to be thrown and not caught by the app, causing it to hang on request.


### Proposal 2
https://github.com/acr-lfr/generate-it-typescript-server/pull/199

After a few points back-and-forth, another proposal was created in order to again achieve the same result, but to address some points above and provide a simpler set of changes to the same extent.
The idea here is that the base exception handler for all errors is doing too much - convert to a serializable error, console log it, and return a json response.
So the idea was to split the conversion into it's own middleware, disable console logging errors, and move handling responses into it's own middleware.
While this solves some of the original issues, it also introduces it's own:

1. By first converting all application errors into HttpExceptions, it prevents users from being able to type-check against other libs (eg `error instanceof SomeNodeModuleException`). It formats all errors into `HttpException`s, including those thrown from other libs (eg typeorm, mongo, etc) which means information in the original error is lost (and cannot be logged properly).
2. It removes any default logging of errors.


### Proposal 3
https://github.com/acr-lfr/generate-it-typescript-server/pull/200

Created to document usage of a custom logger using the current setup. Closed in favour of moving this functionality into the core generated code.


### Proposal 4

You are here -^

Yet another proposal to address the original problem, while attempting to avoid some of the other pitfalls.
It provides a simpler config, which delegates the status code switch (if desired) to the caller while still providing the ability to handle whatever other use-cases might come up in the future.
This also makes these changes opt-in, so that anyone who is using a completely separate logging middleware (for example) is unaffected by this option.
It also does not disable the ability to handle errors from other libraries by converting all errors to the `HttpException` class before the user-defined middleware (eg if you wanted to handle `error instanceof TypeORMError`).
To achieve the same result as proposal 1:
```typescript
import customError500Handle from 'customError500Handle';

export default async (port: number): Promise<Http> => {
  return http(port, {
    errorLogger: (error: HttpException) => {
      switch (error?.status) {
        case 500:
          customError500Handle(error);
          break;
        default:
          console.error(error);
          break;
      }
    },
  });
};

// or more simply:
import { customErrorLogger } from 'custom-error-logger';
export default async (port: number): Promise<Http> => {
  return http(port, {
    errorLogger: customErrorLogger
    },
  });
};
```

Issues with this proposal:
1. Still provides surface area for the user to cause the app to hang (if logErrors throws)
2. Replaces error logging, meaning the user has to console log if they expect to see errors in a terminal / docker / logstash / etc.

1 could be partially addressed with an await try catch around the user method, but the error would then need to be re-circulated into the global exception handler, which is a mess of it's own. This is not an issue if the logging middleware occurs prior to the base exception handler.

I don't think this is a great solution either, but it's an attempt to find a middleground that allows the original custom functionality to be inserted into the app, while not significantly affecting the existing functionality.