### PR TITLE
Feature/pats error logger inject plus splitting http exception

### DIFF
--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -22,6 +22,9 @@ export interface HttpOptions {
 
   // an array of valid express ApplicationRequestHandlers (middlewares) injected AFTER loading routes
   postRouteApplicationRequestHandlers?: any | [string, any][];
+
+  // optional logger which replaces console.error on application error
+  errorLogger?: (error: any) => void;
 }
 
 export default async (port: number, options?: HttpOptions): Promise<Http> => {
@@ -52,7 +55,7 @@ export default async (port: number, options?: HttpOptions): Promise<Http> => {
   if (options?.postRouteApplicationRequestHandlers) {
     useRequestHandlers(options?.postRouteApplicationRequestHandlers);
   }
-  app.use(handleHttpException());
+  app.use(handleHttpException(options.errorLogger));
 
   return {
     expressApp: app,

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -21,10 +21,10 @@ export interface HttpOptions {
   routesImporter?: RoutesImporter;
 
   // An array of valid express ApplicationRequestHandlers (middlewares) injected BEFORE loading routes
-  preRouteMiddleware?: any | [string, any][];
+  requestMiddleware?: any | [string, any][];
 
   // an array of valid express ApplicationRequestHandlers (middlewares) injected AFTER loading routes
-  postRouteMiddleware?: any | [string, any][];
+  errorMiddleware?: any | [string, any][];
 
   // optional logger which replaces console.error on application error
   errorLogger?: (error: any) => void;
@@ -45,8 +45,8 @@ export default async (port: number, options: HttpOptions = {}): Promise<Http> =>
 
   // Generally middlewares that should parse the request before hitting a route
   requestMiddleware(app);
-  if (options.preRouteMiddleware) {
-    useRequestHandlers(options.preRouteMiddleware);
+  if (options.requestMiddleware) {
+    useRequestHandlers(options.requestMiddleware);
   }
 
   // The actual API routes
@@ -56,8 +56,8 @@ export default async (port: number, options: HttpOptions = {}): Promise<Http> =>
   app.use(handleExpress404());
   app.use(handleDomain404());
   app.use(formatErrorMiddeware);
-  if (options.postRouteMiddleware) {
-    useRequestHandlers(options.postRouteMiddleware);
+  if (options.errorMiddleware) {
+    useRequestHandlers(options.errorMiddleware);
   }
   app.use(exceptionLogMiddleware(options.errorLogger));
   app.use(exceptionCatchAll());

--- a/src/http/nodegen/middleware/exceptionCatchAll.ts
+++ b/src/http/nodegen/middleware/exceptionCatchAll.ts
@@ -1,4 +1,3 @@
-import { createHttpExceptionFromErr } from '@/http/nodegen/utils/createHttpExceptionFromErr';
 import * as express from 'express';
 import { HttpException } from '../errors';
 import NodegenRequest from '../interfaces/NodegenRequest';
@@ -8,13 +7,7 @@ import config from '@/config';
  * Http Exception handler
  */
 export default () => {
-  return (err: HttpException, req: NodegenRequest, res: express.Response, next: express.NextFunction) => {
-    if (!(err instanceof HttpException)) {
-      err = createHttpExceptionFromErr(err);
-    }
-
-    console.error(err.stack || err)
-
+  return (err: HttpException, req: NodegenRequest, res: express.Response) => {
     if (err.status === 500 && config.env === 'production') {
       return res.status(err.status).json({ message: 'Internal server error' });
     } else {

--- a/src/http/nodegen/middleware/exceptionLogMiddleware.ts
+++ b/src/http/nodegen/middleware/exceptionLogMiddleware.ts
@@ -1,0 +1,16 @@
+import { HttpException } from '@/http/nodegen/errors';
+import NodegenRequest from '@/http/nodegen/interfaces/NodegenRequest';
+import * as express from 'express';
+
+export default (errorLogger?: (error: any) => void) => {
+  let logErrors = (error: HttpException) => console.error(error.stack || error);
+
+  if (typeof errorLogger === 'function') {
+    logErrors = errorLogger;
+  }
+
+  return (err: HttpException, req: NodegenRequest, res: express.Response, next: express.NextFunction) => {
+    logErrors(err);
+    next(err);
+  };
+}

--- a/src/http/nodegen/middleware/formatErrorMiddeware.ts
+++ b/src/http/nodegen/middleware/formatErrorMiddeware.ts
@@ -1,0 +1,11 @@
+import { HttpException } from '@/http/nodegen/errors';
+import NodegenRequest from '@/http/nodegen/interfaces/NodegenRequest';
+import * as express from 'express';
+import { createHttpExceptionFromErr } from '@/http/nodegen/utils/createHttpExceptionFromErr';
+
+export default (err: HttpException, req: NodegenRequest, res: express.Response, next: express.NextFunction) => {
+  if (!(err instanceof HttpException)) {
+    err = createHttpExceptionFromErr(err);
+  }
+  return next(err);
+}


### PR DESCRIPTION
Option 2 + 3 - the config naming is improved. All "error middlware" now are given the nicely formatted error from createHttpExceptionFromErr() but also allows a custom exception error logger to be injected as per propoal 3