### PR TITLE
Feature/independent errorlog and hook

### DIFF
--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -22,6 +22,9 @@ export interface HttpOptions {
 
   // an array of valid express ApplicationRequestHandlers (middlewares) injected AFTER loading routes
   postRouteApplicationRequestHandlers?: any | [string, any][];
+
+  // optional logger which replaces console.error on application error
+  errorLogger?: (error: any) => void;
 }
 
 export default async (port: number, options?: HttpOptions): Promise<Http> => {
@@ -52,7 +55,7 @@ export default async (port: number, options?: HttpOptions): Promise<Http> => {
   if (options?.postRouteApplicationRequestHandlers) {
     useRequestHandlers(options?.postRouteApplicationRequestHandlers);
   }
-  app.use(handleHttpException());
+  app.use(handleHttpException(options.errorLogger));
 
   return {
     expressApp: app,

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -23,11 +23,24 @@ export interface HttpOptions {
   // an array of valid express ApplicationRequestHandlers (middlewares) injected AFTER loading routes
   errorMiddleware?: any | [string, any][];
 
-  // optional error hook function on application error
-  errorHook?: (error: any) => void;
+  // Options passed to handleHttpException middleware
+  httpException?: {
+    // optional error hook function called on application error
+    errorHook?: (error: any) => void;
 
-  // optional error logger which replaces console.error on application error
-  errorLogger?: (error: any) => void;
+    // optional error logger which replaces console.error on application error
+    errorLogger?: (error: any) => void;
+  };
+
+  /**
+   *  @deprecated Use the requestMiddleware instead
+   */
+  preRouteApplicationRequestHandlers?: any | [string, any][];
+
+  /**
+   *  @deprecated Use the errorMiddleware instead
+   */
+  postRouteApplicationRequestHandlers?: any | [string, any][];
 }
 
 export default async (port: number, options: HttpOptions = {}): Promise<Http> => {
@@ -59,10 +72,7 @@ export default async (port: number, options: HttpOptions = {}): Promise<Http> =>
     useMiddlewares(options.errorMiddleware);
   }
   app.use(
-    handleHttpException({
-      errorLogger: options.errorLogger,
-      errorHook: options.errorHook
-    })
+    handleHttpException(options.httpException)
   );
 
   return {

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -31,7 +31,7 @@ export interface HttpOptions {
 }
 
 export default async (port: number, options: HttpOptions = {}): Promise<Http> => {
-  const app = options?.app || express();
+  const app = options.app || express();
 
   const useMiddlewares = (requestHandlers: Array<(...args: any) => any> | Array<[string, any]>) => {
     requestHandlers.forEach((handler: any) => {

--- a/src/http/nodegen/middleware/handleHttpException.ts
+++ b/src/http/nodegen/middleware/handleHttpException.ts
@@ -17,7 +17,7 @@ export default (options: HttpExceptionOptions = {}) => {
     console.error(error.stack || error);
   };
 
-  if (options.errorLogger && typeof options.errorLogger === 'function') {
+  if (typeof options.errorLogger === 'function') {
     errorLogger = options.errorLogger;
   }
 


### PR DESCRIPTION
see this tread  https://github.com/acr-lfr/generate-it-typescript-server/pull/202

Tested and working nicely, full kitchen sink style example (taken from readme):

```typescript

import express from 'express';
import expressRateLimit from 'express-rate-limit';
import cookieParser from 'cookie-parser'
import path from 'path';
import { typeOrmErrorHandler, httpErrorLogger, httpErrorHook } from 'your-project/common-utils' 
import config from '@/config';
import RabbitMQService from '@/events/rabbitMQ/RabbitMQService';
import http, { Http } from '@/http';

// Rate limiting
const limiter = expressRateLimit({
  windowMs: 15 * 60 * 1000, // 15 minutes
  max: 15 * 60 // 1 request per second
});

/**
 * Returns a promise allowing the server or cli script to know
 * when the app is ready; eg database connections established
 */
export default async (port: number): Promise<Http> => {
  // Here is a good place to connect to databases if required or setup
  // filesystems or any other async action required before starting:
  await RabbitMQService.setup(config.rabbitMQ);

  // Milliseconds for 1 year
  const oneYearMS = 1000 * 60 * 60 * 24 * 365;

  // Return the http layer, to inject custom middleware pass the HttpOptions
  // argument. See the @/http/index.ts
  return http(port, {
    // Injecting static routes, an API limiter an a cookie parser into the app:
    requestMiddleware: [
      ['/image', express.static(path.join(config.file.baseFolderPath, config.file.resizedMount,), { maxAge: oneYearMS })],
      limiter,
      cookieParser
    ],
    // Injecting custom database error handlers making use of the raw error as thrown from the app
    errorMiddleware: [
      typeOrmErrorHandler
    ],
    // Injecting a custom error logger and error hook into the catchall htp exception handeler
    httpException: {
      errorHook: httpErrorHook,
      errorLogger: httpErrorLogger
    }
  });
};

```
