### PR TITLE
WIP: export the spies from jest so they can be unmocked in tests

### DIFF
--- a/src/http/nodegen/tests/___eval.ts
+++ b/src/http/nodegen/tests/___eval.ts
@@ -372,9 +372,18 @@ import { default as AccessTokenService } from '@/services/AccessTokenService';
 import { NextFunction, RequestHandler, Response } from 'express';
 import { default as supertest } from 'supertest';
 
-// sucks these can't be on-demand - jest needs to hoist them so that anything importing them gets the mock.
-jest.mock('morgan', () => () => (req: NodegenRequest, res: Response, next: NextFunction) => next());
-jest.mock('@/http/nodegen/middleware/asyncValidationMiddleware', () => () => (req: NodegenRequest, res: Response, next: NextFunction) => next());
+// to remove these default mocks:
+//   morganSpy.clearAllMocks();
+//   asyncValidationMiddlewareSpy.clearAllMocks();
+export const morganSpy = jest.mock(
+  'morgan',
+  () => () => (req: NodegenRequest, res: Response, next: NextFunction) => next()
+);
+export const asyncValidationMiddlewareSpy = jest.mock(
+  '@/http/nodegen/middleware/asyncValidationMiddleware',
+  () => () => (req: NodegenRequest, res: Response, next: NextFunction) => next()
+);
+
 
 export const baseUrl = root.replace(/\\/*$/, '');
 export let request: supertest.SuperTest<supertest.Test>;


### PR DESCRIPTION
there was previously no way to opt into these mocks, so instead we can just unmock then when we actually want to run them

```ts
import { 
  asyncValidationMiddlewareSpy, 
  defaultSetupTeardown, 
  mockAuth, 
  request 
} from '@/http/nodegen/tests';

defaultSetupTeardown();
dbSetupTeardown();

asyncValidationMiddlewareSpy.clearAllMocks();  // we have async again!
```
