### PR TITLE
Enable passing of custom configuration for Access Logger middleware

### DIFF
--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -1,7 +1,13 @@
 import express, { Express } from 'express';
 import http from 'http';
 import { AddressInfo } from 'net';
-import { handleDomain404, handleExpress404, handleHttpException, requestMiddleware } from '@/http/nodegen/middleware';
+import {
+  AppMiddlewareOptions,
+  handleDomain404,
+  handleExpress404,
+  handleHttpException,
+  requestMiddleware
+} from '@/http/nodegen/middleware';
 import routesImporter, { RoutesImporter } from '@/http/nodegen/routesImporter';
 import packageJson from '../../package.json';
 
@@ -13,6 +19,9 @@ export interface Http {
 export interface HttpOptions {
   // a preconfigured express app, if present the api will use this express app opposed to generating a new one.
   app?: Express;
+
+  // Options injectable into the app middlewares loader
+  appMiddlewareOptions?: AppMiddlewareOptions;
 
   // Options injectable into the routes importer
   routesImporter?: RoutesImporter;
@@ -57,7 +66,7 @@ export default async (port: number, options: HttpOptions = {}): Promise<Http> =>
   };
 
   // Generally middlewares that should parse the request before hitting a route
-  requestMiddleware(app);
+  requestMiddleware(app, options?.appMiddlewareOptions);
   if (options.requestMiddleware) {
     useMiddlewares(options.requestMiddleware);
   }


### PR DESCRIPTION
**Problem:** Implementing healthcheck on K8s results in API logs being spammed by K8s/Docker pinging the healthcheck endpoint. Example log follows:

```log
api                | [api] ::ffff:127.0.0.1 [2023-06-16T10:53:57.748Z] "GET /health HTTP/1.1" 200 2 - 0.793 ms
api                | [api] ::ffff:127.0.0.1 [2023-06-16T10:54:07.818Z] "GET /health HTTP/1.1" 200 2 - 0.776 ms
api                | [api] ::ffff:127.0.0.1 [2023-06-16T10:54:17.899Z] "GET /health HTTP/1.1" 200 2 - 0.742 ms
api                | [api] ::ffff:127.0.0.1 [2023-06-16T10:54:28.001Z] "GET /health HTTP/1.1" 200 2 - 0.749 ms
api                | [api] ::ffff:127.0.0.1 [2023-06-16T10:54:38.109Z] "GET /health HTTP/1.1" 200 2 - 0.754 ms
```

**Solution:** Morgan logger already supports passing a custom (`skip(req: Request, res: Response) => boolean`) function which would allow us to decide if we need to log the call or not.

Example app.ts file:
```typescript
import http, { Http } from '@/http';
// ...

export default async (port: number): Promise<Http> => {
  // ...
  return http(port, {
    // ...
    appMiddlewareOptions: {
      accessLogger: {
        skip: (req) => req.method === 'GET' && req.originalUrl === '/health'
      }
    }
  });
};
```