### PR TITLE
fix - support prettier v3 in templated projects

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -12,7 +12,9 @@ export default (script: string, cliArgs: Record<string, any>): void => {
   }
   const fullPath = path.join(process.cwd(), 'build/src/cli', script + '.js');
   if (!existsSync(fullPath)) {
-    throw new Error(`The script requested "${fullPath}" could not be found. Ensure you pass a string to the command eg "npm run cli-script -- user-seeder"`);
+    throw new Error(
+      `The script requested "${fullPath}" could not be found. Ensure you pass a string to the command eg "npm run cli-script -- user-seeder"`
+    );
   }
 
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -24,4 +26,4 @@ export default (script: string, cliArgs: Record<string, any>): void => {
     .catch((e: any) => {
       console.error('FAILURE: ' + script, e);
     });
-}
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,10 +9,12 @@ dotenv.config();
 export default {
   // Swagger file
   loadSwaggerUIRoute: ConfigHelper.withDefault('LOAD_SWAGGER_UI_ROUTE', false),
-  swaggerBasicAuth: [{
-    basicAuthUname: String(ConfigHelper.withDefault('SWAGGER_BASIC_AUTH_UNAME', 'user')),
-    basicAuthPword: String(ConfigHelper.withDefault('SWAGGER_BASIC_AUTH_PWORD', 'password')),
-  }],
+  swaggerBasicAuth: [
+    {
+      basicAuthUname: String(ConfigHelper.withDefault('SWAGGER_BASIC_AUTH_UNAME', 'user')),
+      basicAuthPword: String(ConfigHelper.withDefault('SWAGGER_BASIC_AUTH_PWORD', 'password')),
+    },
+  ],
 
   // Instance
   env: ConfigHelper.withDefault('ENVIRONMENT', 'production'),
@@ -27,18 +29,12 @@ export default {
 
   // Request worker config - allThreadsCount = processes * threadsPerProcess
   requestWorker: {
-    processes: Number.parseInt(
-      ConfigHelper.withDefault('REQUEST_WORKER_PROCESSES', 1),
-      10
-    ),
-    threadsPerProcess: Number.parseInt(
-      ConfigHelper.withDefault('REQUEST_WORKER_THREADS_PER_PROCESS', 10),
-      10
-    ),
+    processes: Number.parseInt(ConfigHelper.withDefault('REQUEST_WORKER_PROCESSES', 1), 10),
+    threadsPerProcess: Number.parseInt(ConfigHelper.withDefault('REQUEST_WORKER_THREADS_PER_PROCESS', 10), 10),
     timeoutMs: Number.parseInt(
       ConfigHelper.withDefault('REQUEST_WORKER_TIMEOUT_MS', 300000), // 5 minutes
       10
     ),
     silent: true, // disable thread / proc start logs
-  }
+  },
 };

--- a/src/http/nodegen/tests/___eval.ts
+++ b/src/http/nodegen/tests/___eval.ts
@@ -75,9 +75,8 @@ const mapKeys = (map: Map<any, any>) => Array.from(map, ([key]) => key);
 
 const mapValues = (map: Map<any, any>) => Array.from(map, ([_, value]) => value);
 
-const createFormattedFile = (path: string, data: string) =>
-  fs.writeFileSync(
-    path,
+const createFormattedFile = (path: string, data: string) => {
+  Promise.resolve(
     format(data, {
       bracketSpacing: true,
       endOfLine: 'auto',
@@ -87,7 +86,10 @@ const createFormattedFile = (path: string, data: string) =>
       quoteProps: 'consistent',
       filepath: path,
     })
-  );
+  ).then((file) => {
+    fs.writeFileSync(path, file);
+  });
+};
 
 const extractReqParams = (params: Schema.Parameter[], exportData: Map<string, string>, opId: string): ReqParams => {
   if (!params?.length) {

--- a/src/http/nodegen/tests/___eval.ts
+++ b/src/http/nodegen/tests/___eval.ts
@@ -532,7 +532,7 @@ const buildSpecFiles = async (ctx: Context): Promise<void> => {
   const domains = parseAllPaths(ctx.swagger);
   let domainUsesWorkers = false;
 
-  Object.entries(domains).forEach(([opName, domainSpec]) => {
+  for (const domainSpec of Object.values(domains)) {
     const specFileName = `${domainSpec.domainName}`;
     const dataTemplates: string[] = [];
     const stubTemplates: string[] = [];
@@ -567,7 +567,7 @@ const buildSpecFiles = async (ctx: Context): Promise<void> => {
 
     await writeTestHelperFile(`${ctx.dest}/${specFileName}.ts`, domainSpec.domainName, dataTemplates, domainImports.helper);
     await writeTestStubFile(testOutput, domainSpec, stubTemplates, useAuth, domainImports.stub);
-  });
+  };
 
   writeTestIndexFile(`${ctx.dest}/index.ts`, indexExports, domainUsesWorkers);
 };

--- a/src/http/nodegen/tests/___eval.ts
+++ b/src/http/nodegen/tests/___eval.ts
@@ -86,8 +86,8 @@ const createFormattedFile = (path: string, data: string) => {
       quoteProps: 'consistent',
       filepath: path,
     })
-  ).then((file) => {
-    fs.writeFileSync(path, file);
+  ).then((formattedData) => {
+    fs.writeFileSync(path, formattedData);
   });
 };
 

--- a/src/services/AsyncValidationService.ts
+++ b/src/services/AsyncValidationService.ts
@@ -6,7 +6,7 @@ class AsyncValidationService {
    * @param req
    * @param asyncValidatorParams
    */
-  async uniqueUsername (req: NodegenRequest, asyncValidatorParams: string[]): Promise<void> {
+  async uniqueUsername(req: NodegenRequest, asyncValidatorParams: string[]): Promise<void> {
     /**
      * // Run the async function and throw the required error when needed
      * const user = await db.user.find({ username: req.body.username })

--- a/src/services/CacheService.ts
+++ b/src/services/CacheService.ts
@@ -2,7 +2,6 @@ import NodegenRequest from '@/http/interfaces/NodegenRequest';
 import express = require('express');
 
 class CacheService {
-
   /**
    * This middleware is injected into a route via the x-cache parameter present in a path object
    * This middleware is called before the route hits the domain.
@@ -13,7 +12,7 @@ class CacheService {
    * @param next - Express js next function
    * @param transformOutputMap - The output object calculated from the output model defined in the yml
    */
-  public middleware (req: NodegenRequest, res: express.Response, next: express.NextFunction, transformOutputMap: any) {
+  public middleware(req: NodegenRequest, res: express.Response, next: express.NextFunction, transformOutputMap: any) {
     // inject here a redis cache fetch based on your own criteria.
     // generate-it will not overwrite this file, only place it here if it did not already exist.
     // out of the box this function does nothing... how you determine the cache business logic is up to you.

--- a/src/services/HttpHeadersCacheService.ts
+++ b/src/services/HttpHeadersCacheService.ts
@@ -9,7 +9,7 @@ class HttpHeadersCacheService {
    * @param res
    * @param next
    */
-  middleware (req: NodegenRequest, res: express.Response, next: express.NextFunction) {
+  middleware(req: NodegenRequest, res: express.Response, next: express.NextFunction) {
     res.header('Cache-Control', 'no-store, no-cache, must-revalidate');
     res.header('Expires', 'Thu, 19 Nov 1981 08:52:00 GMT');
     next();

--- a/src/services/PermissionService.ts
+++ b/src/services/PermissionService.ts
@@ -3,7 +3,7 @@ import express from 'express';
 // import { ForbiddenException } from '@/http/nodegen/errors';
 
 class PermissionService {
-  middleware (req: NodegenRequest, res: express.Response, next: express.NextFunction, permission: string) {
+  middleware(req: NodegenRequest, res: express.Response, next: express.NextFunction, permission: string) {
     // Please inject your own logic here, below is a very crude and simple example.
     /**
      * This will never be overridden.


### PR DESCRIPTION
If a project bumps their prettier version to v3, the template currently crashes.

Prettier v3 now returns a promise from the format call, so writeFileSync fails.

Wrapping the format in a Promise.resolve and .then ensures that projects on both prettier v2 and v3 can use this template.

WIP Because I'm not sure what the preferred way would be to handle errors here though. If for some reason there's an error with the formatting there will be an uncaught exception which might make for horrible logs.

Some possible options:
- Catching the errors and doing something (could be as simple as console.error and process.exit())
- Refactoring all this code to be async (and handle either async or sync prettier)
- Somehow force prettier to run synchronously

Open to suggestions which I can implement asap. Have patched rrdf with this fix for now but only have a week or so left on the project and don't want to leave it with the monkey patch.