### PR TITLE
feat: Update Dockerfile and docker-compose.yml templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,7 @@ COPY --from=build /code/openapi-nodegen-api-file.yml /code/openapi-nodegen-api-f
 COPY ./docker-entrypoint.sh /sbin/
 RUN chmod 755 /sbin/docker-entrypoint.sh
 
+USER $user
+
 ENTRYPOINT [ "/sbin/docker-entrypoint.sh" ]
 CMD ["prod"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM node:20 AS build
 
-# Arguments defined in docker-compose.yml
-ARG user
-ARG uid
-
 WORKDIR /code
 
 COPY ./package.json ./package-lock.json /code/
@@ -18,16 +14,20 @@ FROM node:20-alpine AS runtime
 WORKDIR /code
 
 COPY --from=build /code/package.json /code/package.json
-RUN npm i --production
+COPY --from=build /code/package-lock.json /code/package-lock.json
+
+RUN npm ci --omit=optional --omit=dev && npm cache clean --force
+RUN npm audit --omit=optional --omit=dev
+
 COPY --from=build /code/node_modules /code/node_modules
 COPY --from=build /code/build /code/build
-
 COPY --from=build /code/openapi-nodegen-api-file.yml /code/openapi-nodegen-api-file.yml
 
 COPY ./docker-entrypoint.sh /sbin/
 RUN chmod 755 /sbin/docker-entrypoint.sh
 
-USER $user
+RUN chown -R node:node /code/
+USER node
 
 ENTRYPOINT [ "/sbin/docker-entrypoint.sh" ]
 CMD ["prod"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ FROM node:20-alpine AS runtime
 WORKDIR /code
 
 COPY --from=build /code/package.json /code/package.json
-
 RUN npm i --production
 COPY --from=build /code/node_modules /code/node_modules
 COPY --from=build /code/build /code/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ COPY --from=build /code/package-lock.json /code/package-lock.json
 RUN npm ci --omit=optional --omit=dev && npm cache clean --force
 RUN npm audit --omit=optional --omit=dev
 
-COPY --from=build /code/node_modules /code/node_modules
 COPY --from=build /code/build /code/build
 COPY --from=build /code/openapi-nodegen-api-file.yml /code/openapi-nodegen-api-file.yml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM node:18 as build
+FROM node:20 AS build
+
+# Arguments defined in docker-compose.yml
+ARG user
+ARG uid
 
 WORKDIR /code
 
@@ -9,13 +13,13 @@ COPY . /code
 RUN npm run build
 
 # -----------------------------------------------------
-FROM node:18-alpine as runtime
+FROM node:20-alpine AS runtime
 
 WORKDIR /code
 
 COPY --from=build /code/package.json /code/package.json
-# FIXME: should only install prod deps for runtime
-# RUN npm i --production
+
+RUN npm i --production
 COPY --from=build /code/node_modules /code/node_modules
 COPY --from=build /code/build /code/build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     build:
       dockerfile: Dockerfile
       context: .
+      args:
+        user: acr
+        uid: 1000
     env_file:
       - .env
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,6 @@ services:
     build:
       dockerfile: Dockerfile
       context: .
-      args:
-        user: acr
-        uid: 1000
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
Update Dockerfile and docker-compose templates to only install prod dependencies on runtime and avoid using the root user.