### PR TITLE
when dataOrPath is null there is no reason to pass this to any response type

### DIFF
--- a/src/http/nodegen/middleware/inferResponseType.ts.njk
+++ b/src/http/nodegen/middleware/inferResponseType.ts.njk
@@ -18,7 +18,7 @@ export default () => {
       outputMap?: Record<string, any>
     ) => {
       // Send only a status when data is undefined
-      if (dataOrPath === undefined) {
+      if (dataOrPath === undefined || dataOrPath === null) {
         return res.sendStatus(status);
       }
 


### PR DESCRIPTION
some route, without a response type:

```
  router.get(
    '/some/route',

    async (req: any, res: GenerateItExpressResponse) => {
      res.inferResponseType(
        await SomeDomain.somethingGet(req),
        200,
        undefined,
        somethingTransformOutputs.somethingGet
      );
    }
```

Some domain:
```
  public async somethingGet (
    req: NodegenRequest
  ): Promise<any> {
    try {
      await callAFunctionFromSomewhere();
    } catch (e) {
      throw new ImATeapotException();
    }
  }
```

Nothing is returned, the promise return is void... the express router then passes `null` to the infer response. Unless you override the object reduce by map, and configure it to accept nullish... this then throws an error.

The oa3 spec file is valid:
```
      responses:
        '200':
          description: OK
```
I don't know if this is node20 which is passing null instead of undefined... i guess when this infer middleware was written "undefined" was passed and not null...

this allows for both