### PR TITLE
fix: the oa3 was incorrectly leaving undefined in the outputs breaking the infer response middleware unless json

### DIFF
--- a/src/http/nodegen/routes/___op.ts.njk
+++ b/src/http/nodegen/routes/___op.ts.njk
@@ -38,7 +38,13 @@ export default function() {
             await {{ucFirst(operation_name)}}Domain.{{path.operationId}}({{pathParamsToDomainParams(method, path, false, true, 'params')}}){% if not path['x-passResponse'] -%},{% endif %}
             {% endif -%}
           {% if not path['x-passResponse'] -%}{{ getSingleSuccessResponse(path.responses) or 200 }},
-            {% if path.produces -%}'{{ path.produces }}'{% else %}undefined{% endif %},
+            {% if path.produces -%}'{{ path.produces }}'
+            {% elif path.responses['200'].content -%}
+               {% set responseKeys = _.keys(path.responses['200'].content) %}
+               '{{ responseKeys[0] }}'
+            {% else %}
+              undefined
+            {% endif %},
             {{_.camelCase(operation_name)}}TransformOutputs.{{path.operationId}}
           ){% endif %}
         }

--- a/src/http/nodegen/routes/___op.ts.njk
+++ b/src/http/nodegen/routes/___op.ts.njk
@@ -40,11 +40,9 @@ export default function() {
           {% if not path['x-passResponse'] -%}{{ getSingleSuccessResponse(path.responses) or 200 }},
             {% if path.produces -%}'{{ path.produces }}'
             {% elif path.responses['200'].content -%}
-               {% set responseKeys = _.keys(path.responses['200'].content) %}
+               {% set responseKeys = _.keys(path.responses['200'].content) -%}
                '{{ responseKeys[0] }}'
-            {% else %}
-              undefined
-            {% endif %},
+            {% else %}undefined{% endif -%},
             {{_.camelCase(operation_name)}}TransformOutputs.{{path.operationId}}
           ){% endif %}
         }


### PR DESCRIPTION
oa2 - nothing changed

oa3: fixed

when the schema looks like this:
```
responses:
  '200':
    description: OK
    content:
      audio/mpeg:
        schema:
          $ref: ../../components/schemas/question/ask/voice/model.yml
```

Instead of the routes file output this::
```
    async (req: any, res: GenerateItExpressResponse) => {
      res.inferResponseType(
        await TextToVoiceDomain.textToVoicePost(req.body, req.jwtData),
        200,
        undefined,
        textToVoiceTransformOutputs.textToVoicePost
      );
    }
```

it now pulls out the correct produces type (assumes the 1st) resulting in:
```
    async (req: any, res: GenerateItExpressResponse) => {
      res.inferResponseType(
        await TextToVoiceDomain.textToVoicePost(req.body, req.jwtData),
        200,
        'audio/mpeg',
        textToVoiceTransformOutputs.textToVoicePost
      );
    }
```

This means the output can be more than just json.. previously for audio/mpeg it would through an error saying audio/mpeg was an invalid response type.