### PR TITLE
noDomainDocBlock option for omitting the doc blocks in the domains

### DIFF
--- a/.nodegenrc
+++ b/.nodegenrc
@@ -5,6 +5,7 @@
   "segmentFirstGrouping": 2,
   "segmentSecondGrouping": 4,
   "helpers": {
+    "noDomainDocBlock": false,
     "stub": {
       "jwtType": "JwtAccess",
       "requestType": "NodegenRequest"

--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ The default `.nodegenrc` will contain:
   "nodegenMockDir": "src/domains/__mocks__",
   "nodegenType": "server",
   "helpers": {
+    "noDomainDocBlock": false,
     "stub": {
       "jwtType": "JwtAccess",
       "requestType": "NodegenRequest",
@@ -332,9 +333,10 @@ The default `.nodegenrc` will contain:
   }
 }
 ```
-The stub helpers will mean the domain method types will be `JwtAccess` or `NodegenRequest` opposed to `any`.
 
-The `NodegenRequest` interface is [provided by these templates](https://github.com/acr-lfr/openapi-nodegen-typescript-server/blob/master/src/http/nodegen/interfaces/NodegenRequest.ts) out of the box so nothing extra required (a domain gets a full req object based on the [core feature](https://acr-lfr.github.io/openapi-nodegen/#/_pages/features?id=pass-full-request-object-to-___stub-method)). This interface extends the express request interface with the additional attributes added by this setup.
+- "noDomainDocBlock" will omit the docblock for each domain method from the output when true.
+- The stub helpers will mean the domain method types will be `JwtAccess` or `NodegenRequest` opposed to `any`.
+  - The `NodegenRequest` interface is [provided by these templates](https://github.com/acr-lfr/openapi-nodegen-typescript-server/blob/master/src/http/nodegen/interfaces/NodegenRequest.ts) out of the box so nothing extra required (a domain gets a full req object based on the [core feature](https://acr-lfr.github.io/openapi-nodegen/#/_pages/features?id=pass-full-request-object-to-___stub-method)). This interface extends the express request interface with the additional attributes added by this setup.
 
 ##### Jwt Definition 
 The `JwtAccess` interface is not provided, it expects that you have in your api file a definition by this name. You can see an example in the core: [example JwtAccess interface](https://github.com/acr-lfr/openapi-nodegen/blob/develop/test_swagger.yml#L176). If you want to use a different interface name, change the value of "jwtType", if you don't want it at all, just delete it from your `.nodegenrc` file.

--- a/src/domains/___stub.ts.njk
+++ b/src/domains/___stub.ts.njk
@@ -23,7 +23,7 @@ class {{ domainClassName }} implements {{ domainInterfaceName }} {
   {% set docBlock = docBlock + '
   **/' %}
 
-  {{ docBlock }}
+  {% if not nodegenRc.helpers.noDomainDocBlock === true -%}{{ docBlock }}{%- endif %}
   {%- set singleSuccessResponse = getSingleSuccessResponse(path['x-response-definitions']) %}
   public async {{ path.operationId }} ({{ pathParamsToDomainParams(method, path, true, false, 'params') }}): Promise<{{ path['x-response-definitions'][singleSuccessResponse] if singleSuccessResponse else 'any' }}> {
     {% if mockServer %}


### PR DESCRIPTION
As the title says really.. 

When true in the rc config file, the tpl will not print the doc block in the domain file.

When the spec url segments are named well, there is little reason for the docblock