### PR TITLE
feat: raw body

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,8 +307,6 @@ class AsyncValidationService {
 }
 ```
 
-
-
 #### Permission helper
 `src/http/nodegen/routes/___op.ts.njk` will look for the `x-permission` attribute within a path object eg:
 ```
@@ -376,6 +374,18 @@ However nice all the automated layer is, once in the domain method it is common 
 It's recommended you use the `Exception.ts` classes when throwing errors - the `4xx.ts` files are deprecated and exist for backwards compatibility reasons.  
 
 Additionally, using the exception classes allows for control over the error response format by passing all errors through the error pre-formatter [HttpErrorsService.ts](src/services/HttpErrorsService.ts). This way, you can define custom error responses for all errors.
+
+#### Raw body
+
+If you require the express raw body add this to the respective path:
+```
+x-raw-body: true
+```
+
+This will result in no validation, no token checks, no body parsing, the domain will be provided the body in a raw format,
+
+If you are handling webhooks from 3rd parties such as Stripe, you will need this flag set.
+
 
 ## Setup
 In a new directory run: `npm init`

--- a/src/http/nodegen/middleware/applicationMiddleware.ts
+++ b/src/http/nodegen/middleware/applicationMiddleware.ts
@@ -35,7 +35,6 @@ export const requestParser = (app: express.Application): void => {
       uploadDir: tmpdir(),
     })
   );
-  app.use(express.json({ limit: '50mb' }));
 
   // clear all empty files (size == 0)
   app.use(expressFormData.format());
@@ -46,6 +45,7 @@ export const requestParser = (app: express.Application): void => {
   // parse the body
   app.use(express.urlencoded({ extended: false }));
 
+  // inject the request ip to the req. object
   app.use(requestIp.mw());
 };
 

--- a/src/http/nodegen/routes/___op.ts.njk
+++ b/src/http/nodegen/routes/___op.ts.njk
@@ -17,19 +17,53 @@ export default function() {
   {% for op in operations -%}
     {% for method, path in op.path -%}
       {% if isValidMethod(method)%}
-  /**
-   * Operation ID: {{ path.operationId }}
-   * {% if path.summary %}Summary: {{ path.summary }}{% endif %}
-   * {% if path.description %}Description: {{ path.description | trim }}{% endif %}
-   */
+      /**
+       * Operation ID: {{ path.operationId }}
+       * {% if path.summary %}Summary: {{ path.summary }}{% endif %}
+       * {% if path.description %}Description: {{ path.description | trim }}{% endif %}
+       */
       {% set securityNames = getSecurityNames(path, swagger) %}
       router.{{method}}(
         '{{op.subresource}}',
-        {% if securityNames %}accessTokenMiddleware({{ securityNames }}  {% if path['x-passThruWithoutJWT'] %}, {passThruWithoutJWT: true}{% endif %}), /* Validate request security tokens */{% endif %}
-        {% if path['x-permission'] %}permissionMiddleware('{{ path['x-permission'] }}'), /* Check permission of the incoming user */ {% endif %}
-        {% if pathsHasParamsToValidate(path) %}celebrate({{ _.camelCase(operation_name) }}Validators.{{path.operationId}}{% if path['x-joi-options'] %}, {{ path['x-joi-options'] | dump }}{% endif %}), /* Validate the request data and return validation errors, options passed in via x-joi-options */ {% endif %}
-        {% if path['x-async-validators'] %}asyncValidationMiddleware({{ path['x-async-validators'] | dump }}), /* Call an async validator function and throw an appropriate error */ {% endif %}
-        {% if path['x-cache'] %}apiCaching({{_.camelCase(operation_name)}}TransformOutputs.{{path.operationId}}), /* Lastly, if x-cache is found, call the api cache middleware */ {% endif %}
+        {%- if path['x-raw-body'] %}
+          /* x-raw-body on path found: Ensure body is raw */
+          express.raw({ type: '*/*' }),
+        {% else -%}
+          /* x-raw-body on path not found: Format the body */
+          express.json({ limit: '50mb' }),
+          {%- if securityNames %}
+            /* security on path found: Validate request security tokens */
+            accessTokenMiddleware(
+              {{ securityNames }},
+              {%- if path['x-passThruWithoutJWT'] %}
+                /* x-passThruWithoutJWT found on path: Inject bool true */
+                {passThruWithoutJWT: true}
+              {% endif -%}
+            ),
+          {% endif -%}
+          {%- if path['x-permission'] %}
+            /* x-permission on path found: Check permission of the incoming user */
+            permissionMiddleware('{{ path['x-permission'] }}'),
+          {% endif -%}
+          {%- if pathsHasParamsToValidate(path) %}
+            /* Validate the request data and return validation errors */
+            celebrate(
+              {{ _.camelCase(operation_name) }}Validators.{{path.operationId}},
+              {%- if path['x-joi-options'] %}
+                /* x-joi-options found on path: inject into celebrate */
+                {{ path['x-joi-options'] | dump }}
+              {% endif -%}
+            ),
+          {% endif -%}
+          {%- if path['x-async-validators'] %}
+            /* x-async-validators on path found: Call an async validator function and throw an appropriate error */
+            asyncValidationMiddleware({{ path['x-async-validators'] | dump }}),
+          {% endif -%}
+          {%- if path['x-cache'] %}
+            /* x-cache found on path: call the api cache middleware */
+            apiCaching({{_.camelCase(operation_name)}}TransformOutputs.{{path.operationId}}),
+          {% endif -%}
+        {% endif -%}
         async (req: any, res: GenerateItExpressResponse) => {
           {% if not path['x-passResponse'] -%}res.inferResponseType( {% endif %}
             {% if path['x-worker'] -%}


### PR DESCRIPTION
If you require the express raw body add this to the respective path:
```
x-raw-body: true
```
This will result in no validation, no token checks, no body parsing, the domain will be provided the body in a raw format,

If you are handling webhooks from 3rd parties such as Stripe, you will need this flag set.
- https://github.com/stripe/stripe-node/blob/master/examples/webhook-signing/express/main.ts#L34

For the `express.raw` to work it cannot be used in combination with `express.json({ limit: '50mb' }),`

As such, the `express.json({ limit: '50mb' }),` or `express.raw({ type: '*/*' }),` are now injected route by route depending on the existence of `x-raw-body: true` in the openapi path file.

Docs extended to accommodate new feature.